### PR TITLE
Add streams to DeleteCommand for multitask deletes

### DIFF
--- a/src/main/java/Coffee/DeleteCommand.java
+++ b/src/main/java/Coffee/DeleteCommand.java
@@ -1,38 +1,49 @@
 package Coffee;
 
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
- * Represents a command to delete a task from the task list.
- * The command parses the user input for the task index,
- * removes the corresponding task, saves the updated list,
+ * Represents a command to delete one or more tasks from the task list.
+ * The command parses the user input for space-separated task indices,
+ * removes the corresponding tasks, saves the updated list,
  * and displays confirmation.
  */
 public class DeleteCommand extends Command {
 
-    private final int index;
+    private final List<Integer> indices;
 
     /**
-     * Constructs a {@code DeleteCommand} with the given task index.
+     * Constructs a {@code DeleteCommand} with the given task indices.
      *
-     * @param args User input string containing the index of the task to delete.
-     *             The value is trimmed and parsed into an integer.
+     * @param args User input string containing space-separated indices
+     *             of the tasks to delete.
      */
     public DeleteCommand(String args) {
-        this.index = Integer.parseInt(args.trim());
+        this.indices = Arrays.stream(args.trim().split("\\s+"))
+                .map(Integer::parseInt)
+                .sorted(Comparator.reverseOrder()) // delete highest index first
+                .collect(Collectors.toList());
     }
 
-    /**
-     * Executes the command by deleting the specified task from the task list.
-     * Saves the updated list to storage and displays confirmation messages to the user.
-     *
-     * @param tasks Task list from which the task will be deleted.
-     * @param ui User interface for displaying messages.
-     * @param storage Storage for saving the updated task list.
-     */
     @Override
     public void execute(TaskList tasks, Ui ui, Storage storage) {
-        Task removed = tasks.deleteTask(index);
+        // Collect results of deletions
+        List<String> results = indices.stream()
+                .map(idx -> {
+                    try {
+                        Task removed = tasks.deleteTask(idx);
+                        return "Noted. I've removed this task:\n" + removed;
+                    } catch (IndexOutOfBoundsException e) {
+                        return "Invalid index: " + idx;
+                    }
+                })
+                .collect(Collectors.toList());
+
         storage.save(tasks.view());
-        ui.showMessage("Noted. I've removed this task:\n" + removed);
+        results.forEach(ui::showMessage);
         ui.showMessage("Now you have " + tasks.size() + " tasks in the list.");
     }
 }


### PR DESCRIPTION
DeleteCommand previously accepted only a single index, which limited its usefulness and required users to issue multiple delete commands to remove more than one task.

This change extends DeleteCommand to parse space-separated indices, allowing users to delete multiple tasks in one command. The indices are sorted in descending order before deletion to prevent index shifting issues. Invalid indices are handled gracefully by returning an error message for each one.

Let's also restructure the logic so that deletions are collected via streams, and all user interface messages are displayed outside the loop. This improves code readability and separates the concerns of deletion and UI output.